### PR TITLE
Add simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 
 # https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
 Gemfile.lock
+coverage

--- a/Guardfile
+++ b/Guardfile
@@ -26,7 +26,8 @@
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 
-guard :rspec, cmd: 'bundle exec rspec --order=defined --format=documentation' do
+guard :rspec, cmd: 'DISABLE_SIMPLECOV=true bundle exec rspec ' \
+                   '--order=defined --format=documentation' do
   require 'guard/rspec/dsl'
   dsl = Guard::RSpec::Dsl.new(self)
 

--- a/date_holidays-reader.gemspec
+++ b/date_holidays-reader.gemspec
@@ -46,6 +46,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop', '~> 1.1'
+  spec.add_development_dependency 'simplecov', '~> 0.19.0'
+  spec.add_development_dependency 'simplecov-console', '~> 0.7'
   spec.add_development_dependency 'terminal-notifier-guard'
 end
 # rubocop:enable Metrics/BlockLength

--- a/date_holidays-reader.gemspec
+++ b/date_holidays-reader.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '~> 1.1'
   spec.add_development_dependency 'terminal-notifier-guard'
 end
 # rubocop:enable Metrics/BlockLength

--- a/lib/date_holidays/reader/holiday.rb
+++ b/lib/date_holidays/reader/holiday.rb
@@ -47,7 +47,7 @@ module DateHolidays
         @substitute
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       # I could cut down on those cops by iterating over instance variable and
       # using meta programming. However, that would obscure intent.
       def ==(other)
@@ -60,7 +60,7 @@ module DateHolidays
           other.substitute? == substitute? &&
           other.note == note
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
       private
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,19 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+# Note that this require is intentionally out of order to load up SimpleCov as
+# soon as possible.
+unless ENV['DISABLE_SIMPLECOV'] == 'true'
+  require 'simplecov'
+  require 'simplecov-console'
+
+  SimpleCov.formatter = SimpleCov::Formatter::Console
+  SimpleCov.start do
+    add_filter %r{\A/spec/}
+    enable_coverage :branch
+  end
+end
+
 require 'bundler/setup'
 require 'date_holidays/reader'
 


### PR DESCRIPTION
This adds code coverage via Simplecov:

![image](https://user-images.githubusercontent.com/403025/98029655-7732f580-1dd5-11eb-9b43-3e89df970bb1.png)

Unfortunately, from what I can find, CircleCI does not support a code coverage badge for the readme.

I also upgraded to Rubocop 1.1. Note that the [monthly gem dependency refresh check](https://app.circleci.com/pipelines/github/bluemarblepayroll/date_holidays-reader/71/workflows/fc1a0544-a0a2-4620-aba3-9683aaf982ff) was failing because of the Rubocop upgrade.

Note that I am not incrementing the version of this gem or planning on doing a Rubygems release as this is all development cleanup.